### PR TITLE
remove DS proprietary options from docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,18 +28,6 @@ To check if the installation was successful, you can run::
 
 It should print something like "3.21.0".
 
-.. _installation-datastax-graph:
-
-(*Optional*) DataStax Graph
----------------------------
-The driver provides an optional fluent graph API that depends on Apache TinkerPop (gremlinpython). It is
-not installed by default. To be able to build Gremlin traversals, you need to install
-the `graph` requirements::
-
-    pip install cassandra-driver[graph]
-
-See :doc:`graph_fluent` for more details about this API.
-
 (*Optional*) Compression Support
 --------------------------------
 Compression can optionally be used for communication between the driver and


### PR DESCRIPTION
The Graph API is not relevant to open source Scylla